### PR TITLE
fix:修复了图片不能直接传递给多模态模型的问题

### DIFF
--- a/utils/image_handler.py
+++ b/utils/image_handler.py
@@ -7,7 +7,7 @@
 """
 
 import asyncio
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from astrbot.api.all import *
 
 
@@ -32,7 +32,7 @@ class ImageHandler:
         image_to_text_prompt: str,
         is_at_message: bool,
         timeout: int = 60,
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[bool, Union[str, List[BaseMessageComponent]]]:
         """
         处理消息中的图片
 
@@ -56,7 +56,7 @@ class ImageHandler:
                 event.message_obj, "message"
             ):
                 # 没有消息链,使用原始文本
-                return True, event.get_message_outline()
+                return True, event.get_messages()
 
             message_chain = event.message_obj.message
 
@@ -67,7 +67,7 @@ class ImageHandler:
 
             # 如果没有图片,直接返回原消息
             if not has_image:
-                return True, event.get_message_outline()
+                return True, event.get_messages()
 
             logger.debug(
                 f"检测到消息包含 {len(image_components)} 张图片, 是否有文字: {has_text}"
@@ -108,7 +108,7 @@ class ImageHandler:
                 logger.debug(
                     "未配置图片转文字提供商ID,保留原始图片信息传递给下游多模态AI"
                 )
-                return True, event.get_message_outline()
+                return True, event.get_messages()
 
             # === 第四步：配置了图片转文字提供商ID，尝试转换图片 ===
             logger.debug(
@@ -145,7 +145,7 @@ class ImageHandler:
         except Exception as e:
             logger.error(f"处理消息图片时发生错误: {e}")
             # 发生错误时,返回原消息文本
-            return True, event.get_message_outline()
+            return True, event.get_messages()
 
     @staticmethod
     def _analyze_message(

--- a/utils/reply_handler.py
+++ b/utils/reply_handler.py
@@ -7,6 +7,7 @@
 """
 
 import asyncio
+from typing import List, Optional
 from astrbot.api.all import *
 from astrbot.core.provider.entities import ProviderRequest
 
@@ -93,6 +94,7 @@ e) 即使话题相关，也要用新的方式表达，展现对话的自然变�
         formatted_message: str,
         extra_prompt: str,
         prompt_mode: str = "append",
+        image_urls: Optional[List[str]] = None,
     ) -> ProviderRequest:
         """
         生成AI回复
@@ -187,7 +189,7 @@ e) 即使话题相关，也要用新的方式表达，展现对话的自然变�
                 func_tool_manager=func_tools_mgr,
                 contexts=contexts,  # 包含begin_dialogs
                 system_prompt=system_prompt,  # 直接使用人格的prompt
-                image_urls=[],
+                image_urls=image_urls if image_urls else [],
             )
 
         except Exception as e:


### PR DESCRIPTION
目前会把图片正确的传递给多模态模型，目前出于成本考虑，会在历史记录中留下[图片]占位符（就和我发的issue图示效果一样）。
<img width="1435" height="333" alt="e9ac655a8d0921fcbcea7dc64a141388" src="https://github.com/user-attachments/assets/e14b2494-c8af-4928-9136-68d7968155d4" />
