### PR TITLE
修复：自动迁移旧版配置类型，避免 WebUI 保存失败

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,6 +158,32 @@ class ChatPlus(Star):
     采用事件监听而非消息拦截，确保与其他插件兼容
     """
 
+    def _migrate_legacy_config_types(self) -> None:
+        """兼容旧版本配置类型，避免 WebUI 全量校验失败。"""
+        key = "_emoji_filter_section_header"
+        default_value = "--- 表情包过滤设置区 ---"
+        try:
+            current_value = self.config.get(key, default_value)
+        except Exception:
+            return
+
+        if not isinstance(current_value, bool):
+            return
+
+        try:
+            self.config[key] = default_value
+            self.config.save_config()
+            logger.warning(
+                "⚠️ 检测到旧版配置类型，已自动迁移: %s bool -> string",
+                key,
+            )
+        except Exception as exc:
+            logger.warning(
+                "⚠️ 旧版配置自动迁移失败，请手动修复 %s: %s",
+                key,
+                exc,
+            )
+
     def __init__(self, context: Context, config: AstrBotConfig):
         """
         初始化插件
@@ -169,6 +195,7 @@ class ChatPlus(Star):
         super().__init__(context)
         self.context = context
         self.config = config
+        self._migrate_legacy_config_types()
 
         # ========== 🔧 配置参数集中提取区块 ==========
         # 说明：为避免 AstrBot 平台多次读取配置可能导致的问题，


### PR DESCRIPTION
## 变更说明
- 在插件启动时增加旧配置类型迁移逻辑
- 当 _emoji_filter_section_header 被历史版本写为布尔值时，自动修正为字符串并保存
- 避免 AstrBot WebUI 在保存任意配置时触发全量校验失败

## 问题背景
历史配置中该字段可能为 false，但当前 schema 期望 string，因此会出现：
错误的类型 _emoji_filter_section_header: 期望是 string, 得到了 bool

Fixes #22
