### PR TITLE
feat(web): allow embedded panel mode

### DIFF
--- a/web/server.py
+++ b/web/server.py
@@ -365,6 +365,15 @@ class WebPanelServer:
         "form-action 'none'; "
         "frame-ancestors 'none';"
     )
+    _CSP_LOGIN_EMBED_TEMPLATE = (
+        "default-src 'none'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; "
+        "script-src 'self' 'nonce-{nonce}'; "
+        "connect-src 'self'; "
+        "form-action 'none'; "
+        "frame-ancestors 'self' http://127.0.0.1:* http://localhost:*;"
+    )
 
     # ---- 面板页 CSP 模板（script-src 使用 nonce，style-src 保留 unsafe-inline 供动态 UI）----
     _CSP_PANEL_TEMPLATE = (
@@ -375,6 +384,15 @@ class WebPanelServer:
         "connect-src 'self'; "
         "form-action 'none'; "
         "frame-ancestors 'none';"
+    )
+    _CSP_PANEL_EMBED_TEMPLATE = (
+        "default-src 'none'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; "
+        "script-src 'self' 'nonce-{nonce}'; "
+        "connect-src 'self'; "
+        "form-action 'none'; "
+        "frame-ancestors 'self' http://127.0.0.1:* http://localhost:*;"
     )
 
     # ---- 错误页 CSP 模板（script-src 使用 nonce）----
@@ -389,14 +407,20 @@ class WebPanelServer:
     )
 
     def _add_security_headers(
-        self, response: web.Response, csp: str = None
+        self, response: web.Response, csp: str = None, allow_frame: bool = False
     ) -> web.Response:
         """向响应添加安全头"""
         for k, v in self._SECURITY_HEADERS.items():
+            if allow_frame and k == "X-Frame-Options":
+                continue
             response.headers[k] = v
         if csp:
             response.headers["Content-Security-Policy"] = csp
         return response
+
+    @staticmethod
+    def _is_embed_request(request: web.Request) -> bool:
+        return request.query.get("embed") == "1"
 
     @staticmethod
     def _generate_nonce() -> str:
@@ -575,19 +599,26 @@ class WebPanelServer:
                 ip, request.method, path, response.status, note=access_note
             )
             if path in {"/", "/error"}:
-                return self._add_security_headers(response)
+                return self._add_security_headers(
+                    response,
+                    allow_frame=path == "/" and self._is_embed_request(request),
+                )
             return response
 
         if path == self._PANEL_PAGE:
             if not auth_result or not auth_result.ok:
-                response = web.HTTPFound("/")
+                login_path = "/?embed=1" if self._is_embed_request(request) else "/"
+                response = web.HTTPFound(login_path)
                 self._clear_auth_cookie(request, response)
                 return response
             request["user"] = auth_result.payload
             request["client_ip"] = ip
             response = await handler(request)
             self.security.log_access(ip, request.method, path, response.status)
-            return self._add_security_headers(response)
+            return self._add_security_headers(
+                response,
+                allow_frame=self._is_embed_request(request),
+            )
 
         if not auth_token:
             self.security.log_access(ip, request.method, path, 401)
@@ -965,11 +996,15 @@ class WebPanelServer:
         """返回登录页（公开，无需认证），使用 nonce-based CSP"""
         content = self._render_login_page()
         if content:
+            embed = self._is_embed_request(request)
             nonce = self._generate_nonce()
             content = self._inject_nonce(content, nonce)
-            csp = self._build_csp(nonce, self._CSP_LOGIN_TEMPLATE)
+            csp_template = (
+                self._CSP_LOGIN_EMBED_TEMPLATE if embed else self._CSP_LOGIN_TEMPLATE
+            )
+            csp = self._build_csp(nonce, csp_template)
             response = web.Response(text=content, content_type="text/html")
-            return self._add_security_headers(response, csp)
+            return self._add_security_headers(response, csp, allow_frame=embed)
         return web.Response(text="登录页文件缺失", status=500)
 
     async def _handle_panel_page(self, request: web.Request):
@@ -979,11 +1014,15 @@ class WebPanelServer:
         except Exception:
             return web.Response(text="面板文件读取失败", status=500)
         if content is not None:
+            embed = self._is_embed_request(request)
             nonce = self._generate_nonce()
             content = self._inject_nonce(content, nonce)
-            csp = self._build_csp(nonce, self._CSP_PANEL_TEMPLATE)
+            csp_template = (
+                self._CSP_PANEL_EMBED_TEMPLATE if embed else self._CSP_PANEL_TEMPLATE
+            )
+            csp = self._build_csp(nonce, csp_template)
             response = web.Response(text=content, content_type="text/html")
-            return self._add_security_headers(response, csp)
+            return self._add_security_headers(response, csp, allow_frame=embed)
         return web.Response(text="面板文件缺失", status=500)
 
     async def _handle_favicon(self, request: web.Request):

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -40,6 +40,11 @@ const App = {
         if (page) page.classList.remove('hidden');
     },
 
+    loginPath() {
+        const isEmbed = new URLSearchParams(window.location.search).get('embed') === '1';
+        return isEmbed ? '/?embed=1' : '/';
+    },
+
     /** 切换主界面视图 */
     showView(name) {
         this._currentView = name;
@@ -858,7 +863,7 @@ const App = {
                     errEl.classList.add('hidden');
                     Api.clearToken();
                     setTimeout(() => {
-                        window.location.href = '/';
+                        window.location.href = App.loginPath();
                     }, 1500);
                 } else {
                     errEl.textContent = res.msg || '修改失败';
@@ -1995,7 +2000,7 @@ const App = {
         this._authMonitor?.stop?.();
         const { showAlert = true } = options;
         const redirect = () => {
-            window.location.href = '/';
+            window.location.href = this.loginPath();
         };
         if (!showAlert || !message || typeof Utils === 'undefined') {
             redirect();

--- a/web/static/js/auth.js
+++ b/web/static/js/auth.js
@@ -3,6 +3,18 @@
  */
 
 const Auth = {
+    _isEmbed() {
+        return new URLSearchParams(window.location.search).get('embed') === '1';
+    },
+
+    _loginPath() {
+        return this._isEmbed() ? '/?embed=1' : '/';
+    },
+
+    _panelPath() {
+        return this._isEmbed() ? '/panel?embed=1' : '/panel';
+    },
+
     init() {
         const btnLogin = document.getElementById('btn-login');
         if (btnLogin) btnLogin.addEventListener('click', () => this.doLogin());
@@ -34,7 +46,7 @@ const Auth = {
         if (!res.password_changed) {
             App.showPage('password-change');
         } else {
-            window.location.href = '/panel';
+            window.location.href = this._panelPath();
         }
     },
 
@@ -53,7 +65,7 @@ const Auth = {
         this._hideError('pw-change-error');
         Utils.alert(res.msg || '密码修改成功，请重新登录').then(() => {
             Api.clearToken();
-            window.location.href = '/';
+            window.location.href = this._loginPath();
         });
     },
 

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -77,6 +77,14 @@
     (function() {
         'use strict';
 
+        var isEmbed = new URLSearchParams(window.location.search).get('embed') === '1';
+        function loginPath() {
+            return isEmbed ? '/?embed=1' : '/';
+        }
+        function panelPath() {
+            return isEmbed ? '/panel?embed=1' : '/panel';
+        }
+
         // 工具函数
         function showError(id, msg) {
             var el = document.getElementById(id);
@@ -102,20 +110,20 @@
 
         // 跳转到面板页
         function navigateToPanel() {
-            window.location.href = '/panel';
+            window.location.href = panelPath();
         }
 
         function handleAuthFailure(res) {
             Api.clearToken();
             if (!res) {
-                window.location.href = '/';
+                window.location.href = loginPath();
                 return;
             }
             var msg = res.msg || '登录已失效，请重新登录';
             if (typeof Utils !== 'undefined' && Utils.alert) {
-                Utils.alert(msg).then(function() { window.location.href = '/'; });
+                Utils.alert(msg).then(function() { window.location.href = loginPath(); });
             } else {
-                window.location.href = '/';
+                window.location.href = loginPath();
             }
         }
 
@@ -201,11 +209,11 @@
                 if (typeof Utils !== 'undefined' && Utils.alert) {
                     Utils.alert(res.msg || '密码修改成功，请重新登录').then(function() {
                         Api.clearToken();
-                        window.location.href = '/';
+                        window.location.href = loginPath();
                     });
                 } else {
                     Api.clearToken();
-                    window.location.href = '/';
+                    window.location.href = loginPath();
                 }
             } catch(e) {
                 showError('pw-change-error', '网络错误，请重试');


### PR DESCRIPTION
## Why

Self Learning can now embed companion plugin dashboards as subpages. Group Chat Plus currently sends `X-Frame-Options: DENY` and `frame-ancestors 'none'`, so its panel cannot load in that controlled embedded flow.

## What Changed

- Add an explicit `?embed=1` mode for the login and panel pages.
- Preserve `embed=1` through login, password-change, logout, and session-expiry redirects.
- Keep the normal anti-frame headers for regular access, while allowing local `localhost` / `127.0.0.1` frame ancestors only in embed mode.

## Verification

- `python -m py_compile web/server.py`
- `node --check web/static/js/app.js`
- `node --check web/static/js/auth.js`
